### PR TITLE
Add option to create PR against base branch other than `master`

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ const githubToken = core.getInput('github_token');
 const repositoryOwner = github.context.repo.owner;
 const repositoryName = github.context.repo.repo;
 const branch = core.getInput('branch');
+const baseBranch = core.getInput( 'base_branch' ) || 'master';
 
 const octokit = github.getOctokit(githubToken);
 
@@ -76,7 +77,7 @@ async function run(): Promise<void> {
       core.info(`Checkout branch ${branch}`);
       await exec('git', ['fetch']);
       await exec('git', ['checkout', branch]);
-      await exec('git', ['rebase', 'origin/master']);
+      await exec('git', ['rebase', `origin/${baseBranch}`]);
     } else {
       core.info(`Create new branch ${branch}`);
       await exec('git', ['checkout', '-b', branch]);
@@ -138,7 +139,7 @@ async function run(): Promise<void> {
           body,
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-non-null-asserted-optional-chain
           repositoryId: query?.repository?.id!,
-          baseRefName: 'master',
+          baseRefName: baseBranch,
           headRefName: branch,
         },
       };

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,7 @@ const githubToken = core.getInput('github_token');
 const repositoryOwner = github.context.repo.owner;
 const repositoryName = github.context.repo.repo;
 const branch = core.getInput('branch');
-const baseBranch = core.getInput( 'base_branch' ) || 'master';
+const baseBranch = core.getInput('base_branch') || 'master';
 
 const octokit = github.getOctokit(githubToken);
 


### PR DESCRIPTION
At this moment, the action only allows creating a PR against the `master` branch, which is problematic for repositories that don't use `master` as the base branch. This creates an error and fails to create a PR ([example](https://github.com/nfmohit/site-kit-wp/actions/runs/3094952221/jobs/5008865985#step:5:167)).

This PR extends the action to allow a `base_branch` input which can be used to define the repository's base branch. `master` is the fallback so that it is backwards-compatible.